### PR TITLE
Added a wizard for access entities

### DIFF
--- a/netprofile_access/netprofile_access/models.py
+++ b/netprofile_access/netprofile_access/models.py
@@ -97,7 +97,7 @@ from netprofile.db.ddl import (
 	Trigger
 )
 from netprofile.ext.columns import MarkupColumn
-from netprofile.ext.wizards import SimpleWizard
+from netprofile.ext.wizards import SimpleWizard, Wizard, Step
 from pyramid.i18n import (
 	TranslationStringFactory,
 	get_localizer
@@ -105,7 +105,7 @@ from pyramid.i18n import (
 
 from netprofile_entities.models import (
 	Entity,
-	EntityType
+	EntityType,
 )
 
 _ = TranslationStringFactory('netprofile_access')
@@ -188,8 +188,20 @@ class AccessEntity(Entity):
 				),
 				'easy_search'  : ('nick',),
 				'extra_data'    : ('grid_icon',),
-				'detail_pane'  : ('netprofile_core.views', 'dpane_simple'),
-				'create_wizard' : SimpleWizard(title=_('Add new access entity'))
+				'detail_pane'  : ('netprofile_entities.views', 'dpane_entities'),
+				'create_wizard' : Wizard(
+					Step(
+						'nick', 'parent',
+						'state', 'flags', 'descr',
+						id='generic', title=_('Generic entity properties')
+					),
+					Step(
+						'password',
+						'stash', 'rate',
+						id='ent_access1', title=_('Access entity properties')
+					),
+					title=_('Add new access entity')
+				)
 			}
 		}
 	)
@@ -333,7 +345,7 @@ class AccessEntity(Entity):
 		}
 	)
 	access_state = Column(
-		'state',
+		'access_code',
 		UInt8(),
 		Comment('Access code'),
 		nullable=False,
@@ -425,6 +437,7 @@ class AccessEntity(Entity):
 		cascade='all, delete-orphan',
 		passive_deletes=True
 	)
+
 
 	def access_state_string(self, req):
 		loc = get_localizer(req)

--- a/netprofile_access/netprofile_access/views.py
+++ b/netprofile_access/netprofile_access/views.py
@@ -289,16 +289,6 @@ def client_login(request):
 	request.run_hook('access.cl.tpldef.login', tpldef, request)
 	return tpldef
 
-#####
-#for aonther oauth provider:
-#add a option to wrapper
-#add another provider oauth function
-#add respective views to __init.py
-#all oauth provider functions must return the same dict reg_params
-#the returned dict is passed to oauth_create function
-#that takes the dict, checks if there's no such user and 
-#add one if everything is OK
-
 @view_config(route_name='access.cl.oauthwrapper', request_method='GET')
 def client_oauth_wrapper(request):
 	auth_provider = request.GET.get('prov', None)
@@ -312,12 +302,7 @@ def client_oauth_wrapper(request):
 		csrf = request.GET.get('csrf', None)
 		email = request.GET.get('twitterEmail', None)
 		if email and csrf == request.get_csrf():
-			#request.params['email'] = email
-			#redirect_uri = 
 			return HTTPFound(location=request.route_url('access.cl.oauthtwitter', email=email))
-			#print("@@@@@@@@@@@@@@@")
-			#print(request.params)
-			#print(redirect_uri)
 	return HTTPSeeOther(redirect_uri)
 
 @view_config(route_name='access.cl.oauthtwitter', request_method='GET')

--- a/netprofile_entities/netprofile_entities/models.py
+++ b/netprofile_entities/netprofile_entities/models.py
@@ -116,6 +116,8 @@ from netprofile_geo.models import (
 	House,
 	Street
 )
+
+
 from netprofile_geo.filters import AddressFilter
 from netprofile.ext.wizards import (
 	ExternalWizardField,
@@ -140,6 +142,7 @@ class EntityType(DeclEnum):
 	legal      = 'legal',      _('Legal'),      20
 	structural = 'structural', _('Structural'), 30
 	external   = 'external',   _('External'),   40
+	access     = 'access',     _('Access'),     50
 
 def _wizcb_ent_generic_next(wiz, step, act, val, req):
 	ret = {
@@ -347,6 +350,14 @@ class Entity(Base):
 						id='ent_external1', title=_('External entity properties'),
 						on_prev='generic',
 						on_submit=_wizcb_ent_submit('ExternalEntity')
+					),
+					Step(
+						ExternalWizardField('AccessEntity', 'password'),
+						ExternalWizardField('AccessEntity', 'stash'),
+						ExternalWizardField('AccessEntity', 'rate'),
+						id='ent_access1', title=_('Access entity properties'),
+						on_prev='generic',
+						on_submit=_wizcb_ent_submit('AccessEntity')
 					),
 					title=_('Add new entity'), validator='CreateEntity'
 				)

--- a/netprofile_entities/netprofile_entities/views.py
+++ b/netprofile_entities/netprofile_entities/views.py
@@ -151,6 +151,8 @@ def new_entity_validator(ret, values, request):
 		em = mod['StructuralEntity']
 	elif etype == 'external':
 		em = mod['ExternalEntity']
+	elif etype == 'access':
+		em = mod['AccessEntity']
 	else:
 		return
 	xret = em.validate_fields(values, request)


### PR DESCRIPTION
I had to rename entities_access.state column to access_code because the wizard for AccessEntity took a value for state from form and tried to insert it to the wrong column raising an error. Now it creates new AcessEntity without any errors